### PR TITLE
API Documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,3 +85,5 @@ gem 'bullet', '~> 7.0'
 gem 'devise', '~> 4.9'
 
 gem 'cancancan'
+
+gem 'rswag'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,8 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.6.3)
+    json-schema (3.0.0)
+      addressable (>= 2.8)
     language_server-protocol (3.17.0.3)
     loofah (2.21.3)
       crass (~> 1.0.2)
@@ -220,6 +222,20 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
+    rswag (2.10.1)
+      rswag-api (= 2.10.1)
+      rswag-specs (= 2.10.1)
+      rswag-ui (= 2.10.1)
+    rswag-api (2.10.1)
+      railties (>= 3.1, < 7.1)
+    rswag-specs (2.10.1)
+      activesupport (>= 3.1, < 7.1)
+      json-schema (>= 2.2, < 4.0)
+      railties (>= 3.1, < 7.1)
+      rspec-core (>= 2.14)
+    rswag-ui (2.10.1)
+      actionpack (>= 3.1, < 7.1)
+      railties (>= 3.1, < 7.1)
     rubocop (1.56.0)
       base64 (~> 0.1.1)
       json (~> 2.3)
@@ -299,6 +315,7 @@ DEPENDENCIES
   rails-controller-testing
   rspec
   rspec-rails
+  rswag
   rubocop (>= 1.0, < 2.0)
   selenium-webdriver
   sprockets-rails

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,14 @@
+Rswag::Api.configure do |c|
+
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.swagger_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,16 @@
+Rswag::Ui.configure do |c|
+
+  # List the Swagger endpoints that you want to be documented through the
+  # swagger-ui. The first parameter is the path (absolute or relative to the UI
+  # host) to the corresponding endpoint and the second is a title that will be
+  # displayed in the document selector.
+  # NOTE: If you're using rspec-api to expose Swagger files
+  # (under swagger_root) as JSON or YAML endpoints, then the list below should
+  # correspond to the relative paths for those endpoints.
+
+  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
   devise_for :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/spec/requests/api/myspec.rb
+++ b/spec/requests/api/myspec.rb
@@ -1,0 +1,4 @@
+# require 'swagger_helper'
+
+# RSpec.describe 'api/my', type: :request do
+# end

--- a/spec/requests/api/v1/comments_spec.rb
+++ b/spec/requests/api/v1/comments_spec.rb
@@ -1,0 +1,41 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/comments', type: :request do
+  path '/api/v1/users/{user_id}/posts/{post_id}/comments' do
+    # You'll want to customize the parameter types...
+    parameter name: 'user_id', in: :path, type: :string, description: 'user_id'
+    parameter name: 'post_id', in: :path, type: :string, description: 'post_id'
+
+    get('list comments') do
+      response(200, 'successful') do
+        let(:user_id) { '123' }
+        let(:post_id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+
+    post('create comment') do
+      response(200, 'successful') do
+        let(:user_id) { '123' }
+        let(:post_id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/posts_spec.rb
+++ b/spec/requests/api/v1/posts_spec.rb
@@ -1,0 +1,23 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/posts', type: :request do
+  path '/api/v1/users/{user_id}/posts' do
+    # You'll want to customize the parameter types...
+    parameter name: 'user_id', in: :path, type: :string, description: 'user_id'
+
+    get('list posts') do
+      response(200, 'successful') do
+        let(:user_id) { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'PostsController', type: :request do
+  let(:user) { User.create(name: 'Test User') }
+  let(:post) { Post.create(author: user, title: 'Test Post') }
+
+  describe 'GET /index' do
+    before do
+      get user_posts_path(user)
+    end
+
+    context 'renders the index template' do
+      it 'response status is correct' do
+        expect(response).to have_http_status(200)
+      end
+      it 'correct template is rendered' do
+        expect(response).to render_template(:index)
+      end
+      it 'the response body includes correct placeholder text' do
+        expect(response.body).to include('posts')
+      end
+    end
+  end
+
+  describe 'GET #show' do
+    before do
+      get user_post_path(user, post)
+    end
+
+    context 'renders the show template' do
+      it 'response status is correct' do
+        expect(response).to have_http_status(200)
+      end
+      it 'correct template is rendered' do
+        expect(response).to render_template(:show)
+      end
+      it 'the response body includes correct placeholder text' do
+        expect(response.body).to include('Post #')
+      end
+    end
+  end
+end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'UsersController', type: :request do
+  let(:user) { User.create(name: 'Test User') }
+
+  describe 'GET /index' do
+    before do
+      get users_path
+    end
+
+    context 'renders the index template' do
+      it 'response status is correct' do
+        expect(response).to have_http_status(200)
+      end
+      it 'correct template is rendered' do
+        expect(response).to render_template(:index)
+      end
+      it 'the response body includes correct placeholder text' do
+        expect(response.body).to include('Users')
+      end
+    end
+  end
+
+  describe 'GET #show' do
+    before do
+      get user_path(user)
+    end
+
+    context 'renders the show template' do
+      it 'response status is correct' do
+        expect(response).to have_http_status(200)
+      end
+      it 'correct template is rendered' do
+        expect(response).to render_template(:show)
+      end
+      it 'the response body includes correct placeholder text' do
+        expect(response.body).to include('Test User')
+      end
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.configure do |config|
+  # Specify a root folder where Swagger JSON files are generated
+  # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
+  # to ensure that it's configured to serve Swagger from the same folder
+  config.swagger_root = Rails.root.join('swagger').to_s
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+  # be generated at the provided relative path under swagger_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a swagger_doc tag to the
+  # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
+  config.swagger_docs = {
+    'v1/swagger.yaml' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'API V1',
+        version: 'v1'
+      },
+      paths: {},
+      servers: [
+        {
+          url: 'https://{defaultHost}',
+          variables: {
+            defaultHost: {
+              default: 'www.example.com'
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
+  # The swagger_docs configuration option has the filename including format in
+  # the key, this may want to be changed to avoid putting yaml in json files.
+  # Defaults to json. Accepts ':json' and ':yaml'.
+  config.swagger_format = :yaml
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'rails_helper'
 
 RSpec.configure do |config|

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,49 @@
+---
+openapi: 3.0.1
+info:
+  title: API V1
+  version: v1
+paths:
+  "/api/v1/users/{user_id}/posts/{post_id}/comments":
+    parameters:
+    - name: user_id
+      in: path
+      description: user_id
+      required: true
+      schema:
+        type: string
+    - name: post_id
+      in: path
+      description: post_id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: list comments
+      responses:
+        '200':
+          description: successful
+    post:
+      summary: create comment
+      responses:
+        '200':
+          description: successful
+  "/api/v1/users/{user_id}/posts":
+    parameters:
+    - name: user_id
+      in: path
+      description: user_id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: list posts
+      responses:
+        '200':
+          description: successful
+servers:
+- url: https://{defaultHost}
+  variables:
+    defaultHost:
+      default: www.example.com
+      


### PR DESCRIPTION
## HI

## Created an API documentation for this project -

## Exercise
In this exercise, you will add documentation for your API endpoints using [rswag](https://github.com/rswag/rswag). Remember that this involves writing the specs that will then be turned into actual documentation and accessible in [swagger-ui](https://github.com/swagger-api/swagger-ui) at `/api-docs`

*IMPORTANT NOTE: Read **all** instructions before you start this exercise.*

### Instructions

1. Write the API integration specs using [rswag](https://github.com/rswag/rswag#getting-started) for your existing endpoints.
2. Generate the documentation.

**You need to use pair-programming for this exercise. Therefore you need to select one of the repos in your pair-programming group in which you will implement the above features (select the one that have API endpoints created).**
